### PR TITLE
Change the environment variable for setting `p2p-host-ip` to be stored in .env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ validator_keys??/
 bls_to_execution_changes/
 backup-wallet/
 slashing-protection-export/
+
+.env

--- a/networks/devnet/agora.bat
+++ b/networks/devnet/agora.bat
@@ -1,7 +1,8 @@
 @ECHO OFF
 FOR /F "tokens=* USEBACKQ" %%F IN (`curl -s https://ifconfig.me/ip`) DO (
-SET P2P_HOST_IP=%%F
+    SET P2P_HOST_IP=%%F
 )
+echo P2P_HOST_IP=%P2P_HOST_IP%>.env
 
 if "%~1"=="" (
   goto printError

--- a/networks/devnet/agora.sh
+++ b/networks/devnet/agora.sh
@@ -536,7 +536,8 @@ elif [ "$1" = "docker-compose" ]; then
 
     fi
 
-    export P2P_HOST_IP=$(curl -s https://ifconfig.me/ip)
+    P2P_HOST_IP=$(curl -s https://ifconfig.me/ip)
+    rm -f "$(pwd)/.env" && echo "P2P_HOST_IP=$P2P_HOST_IP" >> "$(pwd)/.env"
 
     if [ "$2" = "up" ]; then
 
@@ -565,7 +566,8 @@ elif [ "$1" = "docker-compose-monitoring" ]; then
 
     fi
 
-    export P2P_HOST_IP=$(curl -s https://ifconfig.me/ip)
+    P2P_HOST_IP=$(curl -s https://ifconfig.me/ip)
+    rm -f "$(pwd)/.env" && echo "P2P_HOST_IP=$P2P_HOST_IP" >> "$(pwd)/.env"
 
     if [ "$2" = "up" ]; then
 
@@ -586,12 +588,14 @@ elif [ "$1" = "docker-compose-monitoring" ]; then
 
 elif [ "$1" = "start" ]; then
 
-    export P2P_HOST_IP=$(curl -s https://ifconfig.me/ip)
+    P2P_HOST_IP=$(curl -s https://ifconfig.me/ip)
+    rm -f "$(pwd)/.env" && echo "P2P_HOST_IP=$P2P_HOST_IP" >> "$(pwd)/.env"
     docker-compose -f docker-compose-monitoring.yml up -d
 
 elif [ "$1" = "stop" ]; then
 
-    export P2P_HOST_IP=$(curl -s https://ifconfig.me/ip)
+    P2P_HOST_IP=$(curl -s https://ifconfig.me/ip)
+    rm -f "$(pwd)/.env" && echo "P2P_HOST_IP=$P2P_HOST_IP" >> "$(pwd)/.env"
     docker-compose -f docker-compose-monitoring.yml down
 
 elif [ "$1" = "exec" ]; then

--- a/networks/mainnet/agora.bat
+++ b/networks/mainnet/agora.bat
@@ -1,7 +1,8 @@
 @ECHO OFF
 FOR /F "tokens=* USEBACKQ" %%F IN (`curl -s https://ifconfig.me/ip`) DO (
-SET P2P_HOST_IP=%%F
+    SET P2P_HOST_IP=%%F
 )
+echo P2P_HOST_IP=%P2P_HOST_IP%>.env
 
 if "%~1"=="" (
   goto printError

--- a/networks/mainnet/agora.sh
+++ b/networks/mainnet/agora.sh
@@ -529,7 +529,8 @@ elif [ "$1" = "docker-compose" ]; then
 
     fi
 
-    export P2P_HOST_IP=$(curl -s https://ifconfig.me/ip)
+    P2P_HOST_IP=$(curl -s https://ifconfig.me/ip)
+    rm -f "$(pwd)/.env" && echo "P2P_HOST_IP=$P2P_HOST_IP" >> "$(pwd)/.env"
 
     if [ "$2" = "up" ]; then
 
@@ -558,7 +559,8 @@ elif [ "$1" = "docker-compose-monitoring" ]; then
 
     fi
 
-    export P2P_HOST_IP=$(curl -s https://ifconfig.me/ip)
+    P2P_HOST_IP=$(curl -s https://ifconfig.me/ip)
+    rm -f "$(pwd)/.env" && echo "P2P_HOST_IP=$P2P_HOST_IP" >> "$(pwd)/.env"
 
     if [ "$2" = "up" ]; then
 
@@ -579,12 +581,14 @@ elif [ "$1" = "docker-compose-monitoring" ]; then
 
 elif [ "$1" = "start" ]; then
 
-    export P2P_HOST_IP=$(curl -s https://ifconfig.me/ip)
+    P2P_HOST_IP=$(curl -s https://ifconfig.me/ip)
+    rm -f "$(pwd)/.env" && echo "P2P_HOST_IP=$P2P_HOST_IP" >> "$(pwd)/.env"
     docker-compose -f docker-compose-monitoring.yml up -d
 
 elif [ "$1" = "stop" ]; then
 
-    export P2P_HOST_IP=$(curl -s https://ifconfig.me/ip)
+    P2P_HOST_IP=$(curl -s https://ifconfig.me/ip)
+    rm -f "$(pwd)/.env" && echo "P2P_HOST_IP=$P2P_HOST_IP" >> "$(pwd)/.env"
     docker-compose -f docker-compose-monitoring.yml down
 
 elif [ "$1" = "exec" ]; then

--- a/networks/testnet/agora.bat
+++ b/networks/testnet/agora.bat
@@ -1,7 +1,8 @@
 @ECHO OFF
 FOR /F "tokens=* USEBACKQ" %%F IN (`curl -s https://ifconfig.me/ip`) DO (
-SET P2P_HOST_IP=%%F
+    SET P2P_HOST_IP=%%F
 )
+echo P2P_HOST_IP=%P2P_HOST_IP%>.env
 
 if "%~1"=="" (
   goto printError

--- a/networks/testnet/agora.sh
+++ b/networks/testnet/agora.sh
@@ -529,7 +529,8 @@ elif [ "$1" = "docker-compose" ]; then
 
     fi
 
-    export P2P_HOST_IP=$(curl -s https://ifconfig.me/ip)
+    P2P_HOST_IP=$(curl -s https://ifconfig.me/ip)
+    rm -f "$(pwd)/.env" && echo "P2P_HOST_IP=$P2P_HOST_IP" >> "$(pwd)/.env"
 
     if [ "$2" = "up" ]; then
 
@@ -558,7 +559,8 @@ elif [ "$1" = "docker-compose-monitoring" ]; then
 
     fi
 
-    export P2P_HOST_IP=$(curl -s https://ifconfig.me/ip)
+    P2P_HOST_IP=$(curl -s https://ifconfig.me/ip)
+    rm -f "$(pwd)/.env" && echo "P2P_HOST_IP=$P2P_HOST_IP" >> "$(pwd)/.env"
 
     if [ "$2" = "up" ]; then
 
@@ -579,12 +581,14 @@ elif [ "$1" = "docker-compose-monitoring" ]; then
 
 elif [ "$1" = "start" ]; then
 
-    export P2P_HOST_IP=$(curl -s https://ifconfig.me/ip)
+    P2P_HOST_IP=$(curl -s https://ifconfig.me/ip)
+    rm -f "$(pwd)/.env" && echo "P2P_HOST_IP=$P2P_HOST_IP" >> "$(pwd)/.env"
     docker-compose -f docker-compose-monitoring.yml up -d
 
 elif [ "$1" = "stop" ]; then
 
-    export P2P_HOST_IP=$(curl -s https://ifconfig.me/ip)
+    P2P_HOST_IP=$(curl -s https://ifconfig.me/ip)
+    rm -f "$(pwd)/.env" && echo "P2P_HOST_IP=$P2P_HOST_IP" >> "$(pwd)/.env"
     docker-compose -f docker-compose-monitoring.yml down
 
 elif [ "$1" = "exec" ]; then


### PR DESCRIPTION
This was created for Issue #79 
P2P_HOST_IP cannot be removed because --p2p-host-ip must be set in the docker execution environment.
So I had the public IP address recorded in .env.
Therefore, even if the computer is restarted, it will work without any problems.